### PR TITLE
fix: migrate Aliyun Drive API usage to OpenAPI

### DIFF
--- a/clouddrive-cli/__tests__/aliyun.test.ts
+++ b/clouddrive-cli/__tests__/aliyun.test.ts
@@ -26,18 +26,21 @@ describe('aliyunHttp - aliPost', () => {
   beforeEach(() => { vi.stubGlobal('fetch', undefined) })
   afterEach(() => { vi.unstubAllGlobals() })
 
-  it('posts to api.aliyundrive.com for regular paths', async () => {
+  it('maps legacy v3/file/list to openapi.alipan.com openFile/list', async () => {
     const fetchMock = mockFetch({ items: [], next_marker: '' })
     vi.stubGlobal('fetch', fetchMock)
 
-    await aliPost('adrive/v3/file/list', { drive_id: 'x' }, MOCK_TOKEN)
+    await aliPost('adrive/v3/file/list', { drive_id: 'x' }, {
+      ...MOCK_TOKEN,
+      open_api_access_token: 'open-token',
+      open_api_token_type: 'Bearer',
+    })
 
     const [url, opts] = fetchMock.mock.calls[0]
-    expect(url).toContain('api.aliyundrive.com')
-    expect(opts.headers['Authorization']).toBe('Bearer test-access-token')
-    expect(opts.headers['x-device-id']).toBe('test-device-id')
-    expect(opts.headers['x-signature']).toBe('test-signature')
-    expect(opts.headers['x-request-id']).toBeTruthy()
+    expect(url).toContain('openapi.alipan.com')
+    expect(url).toContain('openFile/list')
+    expect(opts.headers['Authorization']).toBe('Bearer open-token')
+    expect(opts.headers['x-device-id']).toBeUndefined()
   })
 
   it('posts to openapi.alipan.com for v1.0 paths', async () => {
@@ -58,14 +61,17 @@ describe('aliyunHttp - aliPost', () => {
 
   it('throws on non-2xx response', async () => {
     vi.stubGlobal('fetch', mockFetch({ message: 'Unauthorized' }, 401))
-    await expect(aliPost('adrive/v3/file/list', {}, MOCK_TOKEN)).rejects.toThrow('401')
+    await expect(aliPost('adrive/v3/file/list', {}, {
+      ...MOCK_TOKEN,
+      open_api_access_token: 'open-token',
+    })).rejects.toThrow('401')
   })
 })
 
 describe('aliyunHttp - aliRefreshToken', () => {
   afterEach(() => { vi.unstubAllGlobals() })
 
-  it('calls auth.aliyundrive.com with refresh_token grant', async () => {
+  it('calls openapi.alipan.com oauth with refresh_token grant', async () => {
     const fetchMock = mockFetch({
       access_token: 'new-access',
       refresh_token: 'new-refresh',
@@ -78,12 +84,15 @@ describe('aliyunHttp - aliRefreshToken', () => {
     const result = await aliRefreshToken(MOCK_TOKEN)
 
     const [url, opts] = fetchMock.mock.calls[0]
-    expect(url).toContain('auth.aliyundrive.com')
+    expect(url).toContain('openapi.alipan.com/oauth/access_token')
     const body = JSON.parse(opts.body)
     expect(body.grant_type).toBe('refresh_token')
     expect(body.refresh_token).toBe('test-refresh-token')
+    expect(body).toHaveProperty('client_id')
+    expect(body).toHaveProperty('client_secret')
     expect(result.access_token).toBe('new-access')
     expect(result.refresh_token).toBe('new-refresh')
+    expect(result.open_api_access_token).toBe('new-access')
   })
 
   it('preserves existing token fields that are missing from response', async () => {
@@ -184,58 +193,46 @@ describe('aliyunFiles - aliListAll', () => {
 describe('aliyunFiles - aliRenameBatch', () => {
   afterEach(() => { vi.unstubAllGlobals() })
 
-  it('sends batch request with correct structure', async () => {
-    const fetchMock = mockFetch({
-      responses: [
-        { id: 'f1', status: 200, body: { name: 'New Name.mkv' } },
-      ],
-    })
+  it('calls openFile/update per file (no v4/batch)', async () => {
+    const fetchMock = mockFetch({ name: 'New Name.mkv', file_id: 'f1' })
     vi.stubGlobal('fetch', fetchMock)
 
     const results = await aliRenameBatch(MOCK_TOKEN, 'drive-001', [
       { fileId: 'f1', newName: 'New Name.mkv' },
     ])
 
-    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
-    expect(body.requests).toHaveLength(1)
-    expect(body.requests[0].url).toBe('/file/update')
-    expect(body.requests[0].body.name).toBe('New Name.mkv')
-    expect(body.requests[0].body.check_name_mode).toBe('refuse')
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toContain('openapi.alipan.com')
+    expect(url).toContain('openFile/update')
+    const body = JSON.parse(opts.body)
+    expect(body.name).toBe('New Name.mkv')
+    expect(body.check_name_mode).toBe('refuse')
+    expect(body.file_id).toBe('f1')
     expect(results[0]).toMatchObject({ fileId: 'f1', status: 'success', newName: 'New Name.mkv' })
   })
 
-  it('reports error status for failed batch items', async () => {
-    vi.stubGlobal('fetch', mockFetch({
-      responses: [
-        { id: 'f2', status: 409, body: { code: 'AlreadyExist', message: 'name conflict' } },
-      ],
-    }))
+  it('reports error status for failed items', async () => {
+    vi.stubGlobal('fetch', mockFetch({ message: 'name conflict', code: 'AlreadyExist' }, 409))
 
     const results = await aliRenameBatch(MOCK_TOKEN, 'drive-001', [
       { fileId: 'f2', newName: 'Conflict.mkv' },
     ])
-    expect(results[0]).toMatchObject({ fileId: 'f2', status: 'error', code: 'AlreadyExist' })
+    expect(results[0]).toMatchObject({ fileId: 'f2', status: 'error' })
+    expect(results[0].message).toMatch(/409|conflict|AlreadyExist/i)
   })
 
-  it('splits into chunks of 100', async () => {
+  it('loops one request per rename (no batch chunking)', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({
-        responses: Array.from({ length: 100 }, (_, i) => ({
-          id: `f${i}`, status: 200, body: { name: `file${i}.mkv` },
-        })),
-      }),
+      json: async () => ({ name: 'ok' }),
+      text: async () => '{}',
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    const renames = Array.from({ length: 150 }, (_, i) => ({ fileId: `f${i}`, newName: `file${i}.mkv` }))
+    const renames = Array.from({ length: 3 }, (_, i) => ({ fileId: `f${i}`, newName: `file${i}.mkv` }))
     await aliRenameBatch(MOCK_TOKEN, 'drive-001', renames)
 
-    expect(fetchMock).toHaveBeenCalledTimes(2)
-    const firstBody = JSON.parse(fetchMock.mock.calls[0][1].body)
-    const secondBody = JSON.parse(fetchMock.mock.calls[1][1].body)
-    expect(firstBody.requests).toHaveLength(100)
-    expect(secondBody.requests).toHaveLength(50)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
   })
 })
 

--- a/clouddrive-cli/core/browserAuth.mjs
+++ b/clouddrive-cli/core/browserAuth.mjs
@@ -404,8 +404,9 @@ async function exchangeAliyunAuthCodeForToken({ authCode, clientId = ALIYUN_OPEN
   let userInfo = {}
   try {
     userInfo = await fetchJson('https://openapi.alipan.com/adrive/v1.0/user/getDriveInfo', {
-      method: 'GET',
-      headers: { Authorization: `Bearer ${token.access_token}` },
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token.access_token}`, 'Content-Type': 'application/json' },
+      body: '{}',
     }, 'Get Aliyun user info failed')
     userInfo = userInfo?.body || userInfo?.data || userInfo
   } catch { /* ignore - fall back to placeholder */ }
@@ -416,6 +417,7 @@ async function exchangeAliyunAuthCodeForToken({ authCode, clientId = ALIYUN_OPEN
 
   if (!userId) throw new Error('Aliyun login: could not retrieve user_id from API. Login failed.')
 
+  const expiresAt = token.expires_in ? Date.now() + Number(token.expires_in) * 1000 : 0
   return {
     provider: 'aliyun',
     accountId: `aliyun_${userId}`,
@@ -427,7 +429,7 @@ async function exchangeAliyunAuthCodeForToken({ authCode, clientId = ALIYUN_OPEN
       open_api_token_type: token.token_type || 'Bearer',
       open_api_access_token: token.access_token || '',
       open_api_refresh_token: token.refresh_token || '',
-      open_api_expires_in: token.expires_in ? Date.now() + Number(token.expires_in) * 1000 : 0,
+      open_api_expires_in: expiresAt,
       expires_in: token.expires_in || 0,
       token_type: token.token_type || 'Bearer',
       user_id: userId,
@@ -436,7 +438,7 @@ async function exchangeAliyunAuthCodeForToken({ authCode, clientId = ALIYUN_OPEN
       name: nickName,
       device_id: clientId,
       default_drive_id: defaultDriveId,
-      expire_time: token.expires_in ? new Date(Date.now() + Number(token.expires_in) * 1000).toISOString() : undefined,
+      expire_time: expiresAt ? new Date(expiresAt).toISOString() : undefined,
     },
   }
 }

--- a/clouddrive-cli/providers/aliyun.mjs
+++ b/clouddrive-cli/providers/aliyun.mjs
@@ -30,9 +30,7 @@ export function createAliyunProvider() {
         throw err
       },
 
-      async refresh(token) {
-        return aliRefreshToken(token)
-      },
+      refresh: aliRefreshToken,
 
       async listAccounts() {
         return []

--- a/clouddrive-cli/providers/aliyunFiles.mjs
+++ b/clouddrive-cli/providers/aliyunFiles.mjs
@@ -88,41 +88,21 @@ export async function aliSearch(token, driveId, query, { limit = 100, orderBy = 
 }
 
 export async function aliRenameBatch(token, driveId, renames) {
-  const BATCH_SIZE = 100
+  // OpenAPI has no /batch endpoint; loop single-file update calls.
   const results = []
-
-  for (let i = 0; i < renames.length; i += BATCH_SIZE) {
-    const chunk = renames.slice(i, i + BATCH_SIZE)
-    const requests = chunk.map(({ fileId, newName }) => ({
-      body: {
+  for (const { fileId, newName } of renames) {
+    try {
+      const data = await aliPost('adrive/v1.0/openFile/update', {
         drive_id: driveId,
         file_id: fileId,
         name: newName,
         check_name_mode: 'refuse',
-      },
-      headers: { 'Content-Type': 'application/json' },
-      id: fileId,
-      method: 'POST',
-      url: '/file/update',
-    }))
-
-    const data = await aliPost('adrive/v4/batch', { requests, resource: 'file' }, token)
-    const responses = data.responses || []
-
-    for (const res of responses) {
-      if (res.status >= 200 && res.status < 300) {
-        results.push({ fileId: res.id, status: 'success', newName: res.body?.name })
-      } else {
-        results.push({
-          fileId: res.id,
-          status: 'error',
-          code: res.body?.code || String(res.status),
-          message: res.body?.message || `HTTP ${res.status}`,
-        })
-      }
+      }, token)
+      results.push({ fileId, status: 'success', newName: data?.name })
+    } catch (e) {
+      results.push({ fileId, status: 'error', code: e.code || 'ERR', message: e.message })
     }
   }
-
   return results
 }
 
@@ -151,24 +131,20 @@ export async function aliDownloadFile(token, driveId, { fileId, outputPath }) {
 }
 
 export async function aliMove(token, driveId, moves) {
-  const BATCH_SIZE = 100
+  // OpenAPI has no /batch endpoint; loop single-file move calls.
   const results = []
-  for (let i = 0; i < moves.length; i += BATCH_SIZE) {
-    const chunk = moves.slice(i, i + BATCH_SIZE)
-    const requests = chunk.map(({ fileId, toParentId }) => ({
-      body: { drive_id: driveId, file_id: fileId, to_drive_id: driveId, to_parent_file_id: toParentId, check_name_mode: 'refuse' },
-      headers: { 'Content-Type': 'application/json' },
-      id: fileId,
-      method: 'POST',
-      url: '/file/move',
-    }))
-    const data = await aliPost('adrive/v4/batch', { requests, resource: 'file' }, token)
-    for (const res of data.responses || []) {
-      if (res.status >= 200 && res.status < 300) {
-        results.push({ fileId: res.id, status: 'success' })
-      } else {
-        results.push({ fileId: res.id, status: 'error', code: res.body?.code || String(res.status), message: res.body?.message || `HTTP ${res.status}` })
-      }
+  for (const { fileId, toParentId } of moves) {
+    try {
+      const data = await aliPost('adrive/v1.0/openFile/move', {
+        drive_id: driveId,
+        file_id: fileId,
+        to_drive_id: driveId,
+        to_parent_file_id: toParentId,
+        check_name_mode: 'refuse',
+      }, token)
+      results.push({ fileId, status: 'success', newFileId: data?.file_id })
+    } catch (e) {
+      results.push({ fileId, status: 'error', code: e.code || 'ERR', message: e.message })
     }
   }
   return results

--- a/clouddrive-cli/providers/aliyunHttp.mjs
+++ b/clouddrive-cli/providers/aliyunHttp.mjs
@@ -3,10 +3,23 @@ import { randomUUID } from 'node:crypto'
 const BASE_API = 'https://api.aliyundrive.com/'
 const BASE_OPEN_API = 'https://openapi.alipan.com/'
 
+// Map legacy aliyundrive API paths (v2/v3/v4, api.aliyundrive.com) to the
+// current OpenAPI paths (openapi.alipan.com/adrive/v1.0/openFile/*).
+// The legacy API domain is shut down (returns 401 AccessTokenInvalid).
+const LEGACY_PATH_MAP = {
+  'adrive/v3/file/list': 'adrive/v1.0/openFile/list',
+  'adrive/v3/file/search': 'adrive/v1.0/openFile/search',
+  'adrive/v3/file/create': 'adrive/v1.0/openFile/create',
+  'adrive/v3/file/recyclebin/trash': 'adrive/v1.0/openFile/recyclebin/trash',
+  'adrive/v3/file/recyclebin/restore': 'adrive/v1.0/openFile/recyclebin/restore',
+  'v2/file/get': 'adrive/v1.0/openFile/get',
+}
+
 function resolveUrl(path) {
   if (path.startsWith('http')) return path
-  if (path.includes('adrive/v1.0') || path.includes('adrive/v1.1')) return BASE_OPEN_API + path
-  return BASE_API + path
+  const mapped = LEGACY_PATH_MAP[path] || path
+  if (mapped.includes('adrive/v1.0') || mapped.includes('adrive/v1.1')) return BASE_OPEN_API + mapped
+  return BASE_API + mapped
 }
 
 function buildHeaders(token, url) {
@@ -41,10 +54,20 @@ export async function aliPost(path, body, token) {
 }
 
 export async function aliRefreshToken(token) {
-  const resp = await fetch('https://auth.aliyundrive.com/v2/account/token', {
+  // Legacy auth.aliyundrive.com is shut down; use OpenAPI oauth (same as browserAuth).
+  // Keep empty-string defaults like HEAD browserAuth (do not hardcode client secrets).
+  const clientId = process.env.CLOUDDRIVE_ALIYUN_CLIENT_ID || process.env.CLOUDDRIVE_ALIPAN_CLIENT_ID || ''
+  const clientSecret = process.env.CLOUDDRIVE_ALIYUN_CLIENT_SECRET || process.env.CLOUDDRIVE_ALIPAN_CLIENT_SECRET || ''
+  const refreshToken = token.open_api_refresh_token || token.refresh_token
+  const resp = await fetch('https://openapi.alipan.com/oauth/access_token', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ refresh_token: token.refresh_token, grant_type: 'refresh_token' }),
+    body: JSON.stringify({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+    }),
   })
   if (!resp.ok) {
     const text = await resp.text().catch(() => '')
@@ -53,18 +76,17 @@ export async function aliRefreshToken(token) {
     throw err
   }
   const data = await resp.json()
+  const expiresAt = data.expires_in ? Date.now() + Number(data.expires_in) * 1000 : 0
   return {
     ...token,
     access_token: data.access_token,
-    refresh_token: data.refresh_token,
+    refresh_token: data.refresh_token || refreshToken,
     expires_in: data.expires_in,
-    expire_time: data.expire_time,
+    expire_time: expiresAt ? new Date(expiresAt).toISOString() : token.expire_time,
     token_type: data.token_type || 'Bearer',
-    default_drive_id: data.default_drive_id || token.default_drive_id,
-    backup_drive_id: data.backup_drive_id || token.backup_drive_id,
-    resource_drive_id: data.resource_drive_id || token.resource_drive_id,
-    user_id: data.user_id || token.user_id,
-    user_name: data.user_name || token.user_name,
-    nick_name: data.nick_name || token.nick_name,
+    open_api_access_token: data.access_token,
+    open_api_refresh_token: data.refresh_token || refreshToken,
+    open_api_token_type: data.token_type || 'Bearer',
+    open_api_expires_in: expiresAt || token.open_api_expires_in,
   }
 }


### PR DESCRIPTION
## Summary

Legacy `api.aliyundrive.com` / `auth.aliyundrive.com` and `v4/batch` no longer work (401 `AccessTokenInvalid`), which breaks clouddrive-cli Aliyun Drive list/browse/rename/move/trash and token refresh.

## Changes (clouddrive-cli only)

- `clouddrive-cli/providers/aliyunHttp.mjs`: add `LEGACY_PATH_MAP` (legacy paths → `openFile/*`); `aliRefreshToken` → `https://openapi.alipan.com/oauth/access_token`
- `clouddrive-cli/providers/aliyunFiles.mjs`: `aliRenameBatch` / `aliMove` drop `v4/batch`, loop `openFile/update` and `openFile/move`
- `clouddrive-cli/core/browserAuth.mjs`: `getDriveInfo` GET → POST (+ JSON body)
- `clouddrive-cli/providers/aliyun.mjs`: `refresh: aliRefreshToken`
- `clouddrive-cli/__tests__/aliyun.test.ts`: expectations updated for OpenAPI

App-side `src/aliapi/*.ts` is intentionally not changed in this PR.

## Test plan

- [x] `vitest run clouddrive-cli/__tests__` — 125 tests passed
- [x] Real run: `clouddrive-cli files list --provider aliyun --json` returned directory listing successfully